### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 🧪 End-to-End Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/30](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/30)

To fix this issue, you should add a `permissions` block at the beginning of the `.github/workflows/e2e-tests.yml` workflow (at root level, below the `name` and above `on`). This block should define the minimal required permissions for all jobs. If jobs only require downloading code and uploading artifacts, the starting point is normally `contents: read` (enables read access to the repository contents, disables writes), and other specific permissions can be added only if later steps require them (such as `pull-requests: write`, if creating PRs). Place this `permissions` block before the `on:` trigger (ideally on line 2, after `name`). This change does not alter workflow functionality, only restricts the permissions of the `GITHUB_TOKEN` to a safer baseline.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
