### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 🧪 End-to-End Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/31](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/31)

To fix this problem, we need to add an explicit `permissions` block to the workflow or to the individual jobs for which CodeQL flagged the error. The best and minimal fix is to specify `permissions: contents: read` at the root level of the workflow, which will apply to all jobs and restrict the `GITHUB_TOKEN` to only reading repo contents. If any job requires broader permissions, its own `permissions` block can be added, but that does not appear necessary in this case. The file to edit is `.github/workflows/e2e-tests.yml`—the permissions block should be inserted just after the workflow `name` and before `on:`. No new methods or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
