### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
 
   docker-test:
     name: 🐳 Docker Build Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: test
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'docker')


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/32](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/32)

The best way to fix the problem is to explicitly add a `permissions` block to the `docker-test` job. According to the principle of least privilege and CodeQL's suggestion, the block should be set to `contents: read`. This restricts the GITHUB_TOKEN to only read repository contents, which is sufficient for actions such as `checkout` and any local build/test processes. The edit should be placed directly under the `name: 🐳 Docker Build Test` field on line 95, within the `docker-test` job. No new methods, imports, or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
