### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: ✅ Simple CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/33](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/33)

To fix the problem, add the `permissions` key to restrict the GITHUB_TOKEN's capabilities, either at the workflow root (for all jobs) or individually for jobs as needed. The minimal fix is to add a root-level `permissions` block specifying only the required permissions, e.g., `contents: read` (for most CI tasks).  
- Edit `.github/workflows/ci.yml` near the top (ideally after the `name:` and before or after `on:`)—add:  
  ```
  permissions:
    contents: read
  ```
- This restricts the GITHUB_TOKEN to only read repository contents, which suffices for checkout, caching, and most reporting.
- If any job (e.g. uploading coverage, posting comments, etc.) genuinely needs write permissions for a specific area, set those as needed at the job-level `permissions` block.
- Based on the code shown, none of the steps requires write permissions—uploading coverage via codecov uses its own token, not GITHUB_TOKEN.  
No imports or further definitions are needed; this is purely a yaml configuration fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
