### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: 🧪 End-to-End Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/35](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/35)

To fix this issue and adhere to the principle of least privilege, we need to add an explicit `permissions:` key to the workflow. As a general rule, workflows which only need to check out code and upload artifacts (such as this one, which runs and uploads test results) should use `permissions: { contents: read }` at the workflow root. This will restrict the `GITHUB_TOKEN` from performing any write actions in the repository. This should be inserted after the `name: ...` line and before the `on:` block. No other changes are necessary, and we do not need to modify any jobs or steps since none appear to require any special write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
