### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -336,6 +336,9 @@ jobs:
 
   test-report:
     name: 📊 Generate Test Report
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: [unit-tests, integration-tests, e2e-tests, performance-tests, security-tests]
     if: always()


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/40](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/40)

To fix this issue, we must add a `permissions` key to the relevant job (`test-report`) in `.github/workflows/e2e-tests.yml`. This should specify the minimal access required for the job to function. For the `test-report` job, most steps are reading contents, uploading/downloading artifacts, and commenting on PRs. At a minimum, `contents: read` is required; to allow PR comments, `pull-requests: write` should also be included. The change should occur directly under the `test-report:` job definition (line 338), before `runs-on: ubuntu-latest`. No additional imports, methods, or dependencies are needed—this is a YAML metadata change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
