### PR TITLE
Potential fix for code scanning alert no. 41: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -434,6 +434,8 @@ jobs:
 
   cleanup:
     name: 🧹 Cleanup
+    permissions:
+      actions: read
     runs-on: ubuntu-latest
     needs: [test-report]
     if: always()


### PR DESCRIPTION
Potential fix for [https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/41](https://github.com/Elpablo777/Telegram-Audio-Downloader/security/code-scanning/41)

To fix the issue, add an explicit `permissions` block to the `cleanup` job in `.github/workflows/e2e-tests.yml`. The minimal necessary permissions for accessing workflow artifacts via the GitHub Actions API is `actions: read`. Since the job does not manipulate contents or write to the repository, more privileged scopes should not be granted. The `permissions` block should appear immediately below the job's name (`name: 🧹 Cleanup`) or above `runs-on:`. No other modifications are required, as the rest of the job does no write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
